### PR TITLE
LOGBACK-1540 - fix login threadName at logback-access

### DIFF
--- a/logback-access/src/main/java/ch/qos/logback/access/spi/AccessEvent.java
+++ b/logback-access/src/main/java/ch/qos/logback/access/spi/AccessEvent.java
@@ -154,7 +154,14 @@ public class AccessEvent implements Serializable, IAccessEvent {
 
     @Override
     public String getThreadName() {
-        return threadName == null ? NA : threadName;
+        try {
++            final String threadName = Thread.currentThread().getName();
++            if (threadName != null) {
++                return threadName;
++            }
++        } catch (Exception ignored) {
++        }
++        return NA;
     }
 
     @Override


### PR DESCRIPTION
https://jira.qos.ch/browse/LOGBACK-1540
this fix logging threadName at logback-access, option 'I' / 'threadName'